### PR TITLE
Specify Mac OS version of libfftw3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EnKF_seir
 
 This code uses an extended SEIR model with age classes in an ensemble data
-assimilation system for predicting the spreading of the Coronavirus.  The ensemble
+assimilation system for predicting the spreading of the Coronavirus. The ensemble
 method is the ESMDA (Ensemble Smoother with multiple data assimilation). The
 measurements are the accumulated number of deaths and the daily number of
 hospitalized.
@@ -15,37 +15,52 @@ hospitalized.
   <a href="https://github.com/geirev/EnKF_seir/blob/master/LICENSE">License</a> 
 </p>
 
-For model, system description, and examples, see 
+For model, system description, and examples, see
 https://www.medrxiv.org/content/10.1101/2020.06.11.20128777v1
 
-Initially, model parameters are sampled from prescribed normal distributions.  The
-ensemble is integrated forward in time to make a prior ensemble prediction.  The
-ESMDA is then used to update the ensemble of model parameters.  After that, the
+Initially, model parameters are sampled from prescribed normal distributions. The
+ensemble is integrated forward in time to make a prior ensemble prediction. The
+ESMDA is then used to update the ensemble of model parameters. After that, the
 posterior ensemble is integrated a final time to produce the posterior prediction.
 
 <p align="center">
 <img src="doc/HDlog.png" width="300"> <img src="doc/RENS.png" width="300">
 </p>
 
-
 ---
-# Installation:
-## 1. Accessing the code
-If you plan to collaborate or contribute anything to the project go for the best installation option.
 
-### 1a. Simple installation option
-Make a directory where you will install the following
+# Installation:
+
+## 1. Building the Project
+
+If you plan to collaborate or contribute anything to the project, use the <a href="#1b-advanced-installation">Advanced Installation</a> option.
+
+### 1a. Basic installation
+
+Create a directory to clone the three following repositories:
+
 ```bash
 git clone git@github.com:geirev/EnKF_seir.git
 git clone git@github.com:geirev/EnKF_analysis.git
 git clone git@github.com:geirev/EnKF_sampling.git
 ```
 
-### 1b. Best installation option
+After cloning, the directory structure should look like:
+
+```bash
+.
+├── EnKF_analysis
+├── EnKF_sampling
+└── EnKF_seir
+```
+
+### 1b. Advanced installation
+
 Make a personal github account unless you already have one.
 Fork the three repositorys listed above.
 Next clone the repositories and set upstream to the original repositories where
 you need to replace <userid> with your github userid
+
 ```bash
 git clone git@github.com:<userid>/EnKF_seir.git
 pushd EnKF_seir
@@ -69,58 +84,167 @@ git remote add upstream https://github.com/geirev/EnKF_sampling
 popd
 ```
 
-If you are new to git, read the section <a href="#git-instructions">Git instructions</a>
+If you are new to Git, read the section <a href="#git-instructions">Git instructions</a>
 
+## 2. Required Packages
 
-## 2. Install blas, lapack, libfftw3, and Fortran95
-<a href="#Mac-OS-X-installation">Additional instructions for installation on Mac OS X</a>
+### Linux
+
 ```bash
 sudo apt-get update
 sudo apt-get install libblas-dev liblapack-dev libfftw3-dev gfortran
 ```
 
-## 3. Compile the EnKF_sampling library
+### Mac
+
+```bash
+brew install gcc fftw openblas lapack
+```
+
+**Note:** You must have [Homebrew](https://brew.sh/) installed to install
+packages using `brew`
+
+## 3. Compile the `EnKF_sampling` library
+
+Navigate to the `lib` folder of the `EnKF_sampling` repository:
+
 ```bash
 cd EnKF_sampling/lib
+```
+
+then compile and place all the `.o` files as well as `libanalysis.a` into
+the `build` directory of the `EnKR_seir` repository using:
+
+```bash
 make BUILD=../../EnKF_seir/build
 ```
-This will put all the .o files as well as libanalysis.a in the same dir as you will use when compiling EnKF_seir
 
-## 4. Compile the EnKF_analysis library
+## 4. Compile the `EnKF_analysis` library
+
+Navigate to the `lib` folder of the `EnKF_analysis`:
+
 ```bash
 cd EnKF_analysis/lib
+```
+
+then compile and place all the `.o` files as well as `libanalysis.a` into the
+`build` directory of the `EnKR_seir` repository using:
+
+```bash
 make BUILD=../../EnKF_seir/build
 ```
-This will put all the .o files as well as libanalysis.a in the same dir as you will use when compiling EnKF_seir.
-Note that EnKF_analysis depends on EnKF sampling.
 
-## 5. cd EnKF_seir/src
-Compile and install executable in target install dir which defaults to BINDIR=/$HOME/bin
+**Note:** The `EnKF_analysis` repository depends on the `EnKF_sampling`
+repository and therefore must be compiled second!
+
+## 5. Compile the `EnKR_seir` library
+
+### Linux
+
+Navigate to the `src` folder of the `EnKF_seir` repository:
+
+```bash
+cd EnKF_seir/src
+```
+
+then compile and install the executable in the target directory, defaulting to
+`$HOME/bin`:
+
 ```bash
 make BINDIR=$HOME/bin
+```
+
+### Mac
+
+Navigate to the `src` folder of the `EnKF_seir` repository:
+
+```bash
+cd EnKF_seir/src
+```
+
+then edit the following line in `EnKF_seir/src/makefile` from:
+
+```bash
+LIBS = ./libsampling.a ./libenkfanalysis.a -llapack -lblas -llapack /usr/lib/x86_64-linux-gnu/libfftw3.so.3
+```
+
+to:
+
+```bash
+LIBS = ./libsampling.a ./libenkfanalysis.a -llapack -lblas -llapack /usr/local/lib/libfftw3.a
+```
+
+then compile and install the executable in the target directory, defaulting to
+`$HOME/bin`:
+
+```bash
+make BINDIR=$HOME/bin
+```
+
+## 6. Run the Project
+
+### Linux
+
+Navigate to the `run` directory of the `EnKF_seir` repository:
+
+```bash
 cd ../run
+```
+
+and run:
+
+```bash
 seir
 ```
 
-## 6. Plotting
-If you have tecplot (tec360) there are .lay and .mcr files in run.
-For some included plotting options check python/enkf_seir/plot:
+### Mac
+
+Create `/usr/local/bin` which allows you to run the `seir` command from anywhere
+on your local file system:
+
+```bash
+mkdir -p /usr/local/bin
+```
+
+then create a symlink for `seir`, noting to `$HOME/bin/seir` to the directory
+where the compiled program is located:
+
+```bash
+ln -s $HOME/bin/seir /usr/local/bin/
+```
+
+then run the project:
+
+```bash
+seir
+```
+
+## 7. Plotting
+
+If you have tecplot (tec360) there are `.lay` and `.mcr` files in the `run`
+directory. For more plotting options, view `python/enkf_seir/plot`:
+
 ```bash
 python ../python/enkf_seir/plot/plot.py
 jupyter-notebook ../python/enkf_seir/plot/covid.ipynb
 ```
 
 ---
+
 # Setting up an experiment
+
 The following explains how to set up and configure your simulations.
 
 Make a directory where you will run the code.
 
-Initially you only need the file 
+Initially you only need the file
+
 ```bash
 infile.in
 ```
+
 copy the example file from the run catalogue and run
+
 ```bash
 seir
 ```
@@ -128,45 +252,58 @@ seir
 This command will then run an ensemble prediction without any data assimilation
 and a number of files are generated.
 
-## Measurements of deaths, hospitalized and number  of positive cases:
+## Measurements of deaths, hospitalized and number of positive cases:
+
 The observations are stored in the file corona.in. See example file for Norway in the run directory.
 The file contains the following columns:
+
 ```bash
 dd/mm-yyyy  "Accumulated number of deaths" "current number of hospitalized" "Accumulated number of cases"
 ```
+
 A negative or zero data value will not be used.
 
 ## Population:
+
 Norwegian population numbers are hard coded and output to two template files.
+
 ```bash
 population.template  : two columns with population of males and females for each age (0-100++)
 agegroups.template   : total population for each agegroup
 ```
+
 You should edit either one of these with your numbers and save the chosen file to either
+
 ```bash
 population.in or agegroups.in
 ```
 
 ## Fraction of mild, severe, and fatally ill per age group:
+
 The file
+
 ```bash
-pfactors.in          
+pfactors.in
 ```
+
 is generated with some default values, which can be edited and changed.
 
-
 ## R-reproduction in between age groups:
+
 The model contains 11 age-groups and allows for using different R numbers between different age groups.
 Currently, three matrices are generated all with the number 1.00 for all transsmission. These can later be
 edited to represent different scenarios.
+
 ```bash
 Rmatrix_01.in
 Rmatrix_02.in
 Rmatrix_03.in
 ```
-The actual R-numbers are R = p%R(k) * Rmatrix_k  where P%R(k) comes from the infile.in
+
+The actual R-numbers are R = p%R(k) \* Rmatrix_k where P%R(k) comes from the infile.in
 
 ## Output files:
+
 ```bash
 susc_0.dat   susc_1.dat   : Prior and posterior susceptability (accumualted)
 recov_0.dat  recov_1.dat  : Prior and posterior recovered (accumualted)
@@ -181,9 +318,10 @@ par0.dat par1.dat         : Prior and posterior ensemble of parameters
 Rens_0.dat Rens_1.dat     : Prior and posterior ensemble of R(t)
 ```
 
-
 ---
+
 # Code standards
+
 If you plan to change the code note the following:
 
 I always define subroutines in new modules:
@@ -198,6 +336,7 @@ subroutine name_of_sub
 end subroutine
 end module
 ```
+
 in the main program you write
 
 ```Fortran90
@@ -211,15 +350,15 @@ The main program then has access to all the global variables defined in the modu
 knows the header of the subroutine and the compiler checks the consistency between the call
 and the subroutine definition.
 
-   make new  -> updates the dependencies for the makefile
-   make tags -> runs ctags (useful if you use vim)
+make new -> updates the dependencies for the makefile
+make tags -> runs ctags (useful if you use vim)
 
 For this to work install the scripts in the ./bin in your path and install ctags
 
-
-
 ---
+
 # Git instructions
+
 When working with git repositories other than the ones you own, and when you expect to contribute to the code,
 a good way got organize your git project is described in https://opensource.com/article/19/7/create-pull-request-github
 
@@ -236,6 +375,7 @@ git remote -v                   #   should list both your local and remote repos
 ```
 
 To keep your local master branch up to date with the upstream code (my original repository)
+
 ```bash
 git checkout master             #   unless you are not already there
 git fetch upstream              #   get info about upstream repo
@@ -243,10 +383,13 @@ git merge upstream/master       #   merges upstream master with your local maste
 ```
 
 If you want to make changes to the code:
+
 ```bash
 git checkout -b branchname      #   Makes a new branch and moves to it
 ```
+
 Make your changes
+
 ```bash
 git add .                       #   In the root of your repo, stage for commit
 git status                      #   Tells you status
@@ -254,14 +397,16 @@ git commit                      #   Commits your changes to the local repo
 ```
 
 Push to your remote origin repo
+
 ```bash
 git push -u origin branchname   #   FIRST TIME to create the branch on the remote origin
 git push                        #   Thereafter: push your local changes to your forked  origin repo
 ```
 
-
 To make a pull request:
+
 1. Commit your changes on the local branch
+
 ```bash
 git add .                       #   In the root of your repo, stage for commit
 git status                      #   Tells you status
@@ -269,6 +414,7 @@ git commit                      #   Commits your changes to the local repo
 ```
 
 2. Update the branch where you are working to be consistent with the upstream master
+
 ```bash
 git checkout master             #   unless you are not already there
 git fetch upstream              #   get info about upstream repo
@@ -278,12 +424,15 @@ git rebase master               #   your branch is updated by adding your local 
 ```
 
 3. squash commits into one (if you have many commits)
+
 ```bash
 git log                      #   lists commits
 git rebase -i indexofcommit  #   index of commit before your first commit
 ```
+
 Change pick to squash for all commits except the latest one.
 save and then make a new unified commit message.
+
 ```bash
 git push --force             #   force push branch to origin
 ```
@@ -298,9 +447,10 @@ Every time you need to know something just search for git "how to do something" 
 For advanced users:
 Set the sshkey so you don't have to write a passwd everytime you push to your remote repo: check settings / keys tab
 Follow instructions in
-   https://help.github.com/en/github/using-git/changing-a-remotes-url
+https://help.github.com/en/github/using-git/changing-a-remotes-url
 
 To make your Linux terminal show you the current branch in the prompt include the follwoing in your .bashrc
+
 ```bash
 parse_git_branch() {
      git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
@@ -309,15 +459,17 @@ export PS1="\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[1;31m\]\w\[\033[0;93m\]\$(pa
 ```
 
 ---
+
 # Definition of time
+
 The model uses the following definitions for time:
 
-"Startdate" e.g., 01/03-2020  denote that the model runs from 00:00am 01/03-2020, and this time is
+"Startdate" e.g., 01/03-2020 denote that the model runs from 00:00am 01/03-2020, and this time is
 set to t=0.0. (see the table below)
 
 The system integreates the ensemble of models forward one day at the time, starting from 00:00 to
 24:00 and thus outputs the solutions at midnight end of the day. Thus, the output files will
-contain entries like 
+contain entries like
 
 ```
  model time                                                         Output date
@@ -330,38 +482,19 @@ contain entries like
 ```
 
 ## Intervention times:
+
 If an intevention time is defined as 15/03-2020 the intervention is avtive (through values of R)
-from the morning on the 15/03 at 00:00am, which corresponds to model time t>14.0.  This means that
+from the morning on the 15/03 at 00:00am, which corresponds to model time t>14.0. This means that
 R(t) switches from R1 to R2 from the morning of 15/03. Accordingly ir swiches from 1 to 2 for using
 the correct Rmat(ir).
 
 ## Measurement times
+
 A measurement for a particular day is located at midnight that day. Thus, given a measurement from
 corona.in, e.g.,
+
 ```bash
  03/03-2020    7   154   2206
 ```
+
 will be located at the same time as the output of day 3, i.e., the end of the day.
-
----
-# Mac OS X installation
-These are just amendments to GE’s instructions for those on Mac OS X
-(need git and homebrew)
-
-Instead of doing the apt-get for libraries do:
-
-brew install gcc
-brew install fftw
-brew install openblas
-brew install lapack
-
-Follow instructions on the git, with cloning etc, until step 5:
-Still do: cd EnKF_seir/src
-
-But then go into the makefile and delete “/usr/lib/x86_64-linux-gnu/libfftw3.so.3” and replace that with “-lfftw3”
-
-(mine is linked here: https://github.com/clairevalva/EnKF_seir/blob/master/src/makefile)
-
-So the line should look like: “LIBS =  ./libsampling.a ./libenkfanalysis.a -llapack -lblas  -llapack -lfftw3”
-
-Continue following the instructions where GE left off, except you run executables on the mac as ./seir rather than seir


### PR DESCRIPTION
Hi there!

My colleague and I had a very rough time setting up the `EnKR_seir` project both on Mac OS (Catalina - `10.15.6`) as well as an Ubuntu VM running on Parallels. However, after several hours, we were successful in compiling and running the project on Mac OS!

I'd love to work together to help land this patch to improve the setup experience for Mac OS users.

View the `README` here: https://github.com/geirev/EnKF_seir/blob/ed3bc4d12639312a149ef717139f899c7861b197/README.md


**Patch notes:**

```
When installing the `fftw` using brew into `/usr/local/lib`, the
Makefile located in `src` must be updated to reference the `libfftw3`
library found in `/usr/local/lib` to be able to compile EnKF_seir.

In addition, the README has been updated to specify respective commands
for Linux and Mac OS, with a special note in the `Mac` section of `Run
the Project`, to add a symlink to enable users to run `seir` from
anywhere on their Mac file system.

Lastly, other syntactical updates have been made to the README for
consistency.
```